### PR TITLE
Refactor to centralize template handling.  

### DIFF
--- a/includes/classes/osc_template.php
+++ b/includes/classes/osc_template.php
@@ -5,12 +5,13 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2018 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
 
   class oscTemplate {
+
     var $_title;
     var $_blocks = array();
     var $_content = array();
@@ -170,5 +171,10 @@
 
       return $result;
     }
+
+    public function map_to_template($file) {
+      return dirname($file) . '/templates/tpl_' . basename($file);
+    }
+
   }
   

--- a/includes/modules/block_template.php
+++ b/includes/modules/block_template.php
@@ -1,0 +1,16 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2019 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+ob_start();
+include($GLOBALS['oscTemplate']->map_to_template($tpl_data['file']));
+
+$GLOBALS['oscTemplate']->addBlock(ob_get_clean(), $tpl_data['group']);

--- a/includes/modules/content/cm_template.php
+++ b/includes/modules/content/cm_template.php
@@ -1,0 +1,16 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2019 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  ob_start();
+  include($GLOBALS['oscTemplate']->map_to_template($tpl_data['file']));
+
+  $GLOBALS['oscTemplate']->addContent(ob_get_clean(), $tpl_data['group']);


### PR DESCRIPTION
This centralizes the template handling so that it 

1.  Doesn't have to be repeated everywhere.  
2.  Can be changed in just a few places and affect everywhere.  
3.  Prepares for a future where templates can be installed without overriding core code.  

I have tested this by viewing a page that uses the new code.  I verified that it was using the new code by deliberately breaking it.  After fixing the code again, the broken part returned.  This can be called like 
```
      $tpl_data = [ 'group' => $this->group, 'file' => __FILE__ ];
      include 'includes/modules/content/cm_template.php';
```
or
```
      $tpl_data = [ 'group' => $this->group, 'file' => __FILE__ ];
      include 'includes/modules/block_template.php';
```
I realize that this isn't much shorter, but that's not the real point.  The real advantage here is not related to code length but to reusability.  There are basically three patterns that appear about eighty times total:  Navbar modules; boxes; and content modules.  To change these will take about eighty edits.  But this way, once changed they can be modified with just the two template module files.  

This change is backwardly compatible, as it doesn't make the old way stop working.  It just offers a better alternative.  

The main reason that I want this is that I'm going to have to make additional calls like this and would like not to have to redo them later.  