### PR TITLE
Bootstrap box template

### DIFF
--- a/admin/includes/classes/box.php
+++ b/admin/includes/classes/box.php
@@ -5,56 +5,40 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2003 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 
   Example usage:
 
-  $heading = array();
-  $heading[] = array('params' => 'class="menuBoxHeading"',
-                     'text'  => BOX_HEADING_TOOLS,
-                     'link'  => tep_href_link(basename($PHP_SELF));
+  $heading = [];
+  $heading[] = ['text'  => BOX_HEADING_TOOLS];
 
-  $contents = array();
-  $contents[] = array('text'  => SOME_TEXT);
+  $contents = [];
+  $contents[] = ['text'  => SOME_TEXT];
 
-  $box = new box;
+  $box = new box();
   echo $box->infoBox($heading, $contents);
 */
 
   class box extends tableBlock {
-	function __construct() {
-      $this->heading = array();
-      $this->contents = array();
-    }
+
+    private $this->heading = [];
+    private $this->contents = [];
 
     function infoBox($heading, $contents) {
-      $this->table_row_parameters = 'class="infoBoxHeading"';
-      $this->table_data_parameters = 'class="infoBoxHeading"';
-      $this->heading = $this->tableBlock($heading);
+      if (is_array($heading)) {
+        $heading = $heading[0]['text'];
+      }
 
       $this->table_row_parameters = '';
       $this->table_data_parameters = 'class="infoBoxContent"';
-      $this->contents = $this->tableBlock($contents);
+      $contents = $this->tableBlock($contents);
 
-      return $this->heading . $this->contents;
+      ob_start();
+      include dirname(__FILE__) . '/templates/tpl_box.php';
+
+      return ob_get_clean();
     }
 
-    function menuBox($heading, $contents) {
-      $this->table_data_parameters = 'class="menuBoxHeading"';
-      if (isset($heading[0]['link'])) {
-        $this->table_data_parameters .= ' onmouseover="this.style.cursor=\'hand\'" onclick="document.location.href=\'' . $heading[0]['link'] . '\'"';
-        $heading[0]['text'] = '&nbsp;<a href="' . $heading[0]['link'] . '" class="menuBoxHeadingLink">' . $heading[0]['text'] . '</a>&nbsp;';
-      } else {
-        $heading[0]['text'] = '&nbsp;' . $heading[0]['text'] . '&nbsp;';
-      }
-      $this->heading = $this->tableBlock($heading);
-
-      $this->table_data_parameters = 'class="menuBoxContent"';
-      $this->contents = (!empty($contents) ? $this->tableBlock($contents) : '');
-
-      return $this->heading . $this->contents;
-    }
   }
-?>

--- a/admin/includes/classes/templates/tpl_box.php
+++ b/admin/includes/classes/templates/tpl_box.php
@@ -1,0 +1,15 @@
+<div class="card infobox">
+  <span class="card-header infoBoxHeading"><?php echo $heading ?></span>
+  <div class="card-body"><?php echo $contents ?></div>
+</div>
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2019 osCommerce
+
+  Released under the GNU General Public License
+*/


### PR DESCRIPTION
Update box class to use a Bootstrap template to display heading and contents as I proposed in [issue #840](https://github.com/gburton/CE-Phoenix/issues/840).  I did not change the display of the contents from tableBlock.  

Note that this will require at least changes to stylesheet.css and may require more edits to the template in order to make it pretty/consistent with other content.  

While there, I deleted the deprecated menuBox code.  