### PR TITLE
Break checkout processing into parts

### DIFF
--- a/checkout_process.php
+++ b/checkout_process.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2012 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
@@ -80,56 +80,7 @@
 // load the before_process function from the payment modules
   $payment_modules->before_process();
 
-  $sql_data_array = array('customers_id' => $customer_id,
-                          'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
-                          'customers_company' => $order->customer['company'],
-                          'customers_street_address' => $order->customer['street_address'],
-                          'customers_suburb' => $order->customer['suburb'],
-                          'customers_city' => $order->customer['city'],
-                          'customers_postcode' => $order->customer['postcode'], 
-                          'customers_state' => $order->customer['state'], 
-                          'customers_country' => $order->customer['country']['title'], 
-                          'customers_telephone' => $order->customer['telephone'], 
-                          'customers_email_address' => $order->customer['email_address'],
-                          'customers_address_format_id' => $order->customer['format_id'], 
-                          'delivery_name' => trim($order->delivery['firstname'] . ' ' . $order->delivery['lastname']),
-                          'delivery_company' => $order->delivery['company'],
-                          'delivery_street_address' => $order->delivery['street_address'], 
-                          'delivery_suburb' => $order->delivery['suburb'], 
-                          'delivery_city' => $order->delivery['city'], 
-                          'delivery_postcode' => $order->delivery['postcode'], 
-                          'delivery_state' => $order->delivery['state'], 
-                          'delivery_country' => $order->delivery['country']['title'], 
-                          'delivery_address_format_id' => $order->delivery['format_id'], 
-                          'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'], 
-                          'billing_company' => $order->billing['company'],
-                          'billing_street_address' => $order->billing['street_address'], 
-                          'billing_suburb' => $order->billing['suburb'], 
-                          'billing_city' => $order->billing['city'], 
-                          'billing_postcode' => $order->billing['postcode'], 
-                          'billing_state' => $order->billing['state'], 
-                          'billing_country' => $order->billing['country']['title'], 
-                          'billing_address_format_id' => $order->billing['format_id'], 
-                          'payment_method' => $order->info['payment_method'], 
-                          'cc_type' => $order->info['cc_type'], 
-                          'cc_owner' => $order->info['cc_owner'], 
-                          'cc_number' => $order->info['cc_number'], 
-                          'cc_expires' => $order->info['cc_expires'], 
-                          'date_purchased' => 'now()', 
-                          'orders_status' => $order->info['order_status'], 
-                          'currency' => $order->info['currency'], 
-                          'currency_value' => $order->info['currency_value']);
-  tep_db_perform('orders', $sql_data_array);
-  $insert_id = tep_db_insert_id();
-  for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-    $sql_data_array = array('orders_id' => $insert_id,
-                            'title' => $order_totals[$i]['title'],
-                            'text' => $order_totals[$i]['text'],
-                            'value' => $order_totals[$i]['value'], 
-                            'class' => $order_totals[$i]['code'], 
-                            'sort_order' => $order_totals[$i]['sort_order']);
-    tep_db_perform('orders_total', $sql_data_array);
-  }
+  require 'includes/modules/checkout/insert_order.php';
 
   $customer_notification = (SEND_EMAILS == 'true') ? '1' : '0';
   $sql_data_array = array('orders_id' => $insert_id, 
@@ -139,162 +90,13 @@
                           'comments' => $order->info['comments']);
   tep_db_perform('orders_status_history', $sql_data_array);
 
-// initialized for the email confirmation
-  $products_ordered = '';
-
-  for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-// Stock Update - Joao Correia
-    if (STOCK_LIMITED == 'true') {
-      if (DOWNLOAD_ENABLED == 'true') {
-        $stock_query_raw = "SELECT products_quantity, pad.products_attributes_filename 
-                            FROM products p
-                            LEFT JOIN products_attributes pa
-                             ON p.products_id=pa.products_id
-                            LEFT JOIN products_attributes_download pad
-                             ON pa.products_attributes_id=pad.products_attributes_id
-                            WHERE p.products_id = '" . tep_get_prid($order->products[$i]['id']) . "'";
-// Will work with only one option for downloadable products
-// otherwise, we have to build the query dynamically with a loop
-        $products_attributes = (isset($order->products[$i]['attributes'])) ? $order->products[$i]['attributes'] : '';
-        if (is_array($products_attributes)) {
-          $stock_query_raw .= " AND pa.options_id = '" . (int)$products_attributes[0]['option_id'] . "' AND pa.options_values_id = '" . (int)$products_attributes[0]['value_id'] . "'";
-        }
-        $stock_query = tep_db_query($stock_query_raw);
-      } else {
-        $stock_query = tep_db_query("select products_quantity from products where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-      }
-      if (tep_db_num_rows($stock_query) > 0) {
-        $stock_values = tep_db_fetch_array($stock_query);
-// do not decrement quantities if products_attributes_filename exists
-        if ((DOWNLOAD_ENABLED != 'true') || (!$stock_values['products_attributes_filename'])) {
-          $stock_left = $stock_values['products_quantity'] - $order->products[$i]['qty'];
-        } else {
-          $stock_left = $stock_values['products_quantity'];
-        }
-        tep_db_query("update products set products_quantity = '" . (int)$stock_left . "' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-        if ( ($stock_left < 1) && (STOCK_ALLOW_CHECKOUT == 'false') ) {
-          tep_db_query("update products set products_status = '0' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-        }
-      }
-    }
-
-// Update products_ordered (for bestsellers list)
-    tep_db_query("update products set products_ordered = products_ordered + " . sprintf('%d', $order->products[$i]['qty']) . " where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-
-    $sql_data_array = array('orders_id' => $insert_id, 
-                            'products_id' => tep_get_prid($order->products[$i]['id']), 
-                            'products_model' => $order->products[$i]['model'], 
-                            'products_name' => $order->products[$i]['name'], 
-                            'products_price' => $order->products[$i]['price'], 
-                            'final_price' => $order->products[$i]['final_price'], 
-                            'products_tax' => $order->products[$i]['tax'], 
-                            'products_quantity' => $order->products[$i]['qty']);
-    tep_db_perform('orders_products', $sql_data_array);
-    $order_products_id = tep_db_insert_id();
-
-//------insert customer choosen option to order--------
-    $attributes_exist = '0';
-    $products_ordered_attributes = '';
-    if (isset($order->products[$i]['attributes'])) {
-      $attributes_exist = '1';
-      for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-        if (DOWNLOAD_ENABLED == 'true') {
-          $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename 
-                               from products_options popt, products_options_values poval, products_attributes pa 
-                               left join products_attributes_download pad
-                                on pa.products_attributes_id=pad.products_attributes_id
-                               where pa.products_id = '" . (int)$order->products[$i]['id'] . "' 
-                                and pa.options_id = '" . (int)$order->products[$i]['attributes'][$j]['option_id'] . "' 
-                                and pa.options_id = popt.products_options_id 
-                                and pa.options_values_id = '" . (int)$order->products[$i]['attributes'][$j]['value_id'] . "' 
-                                and pa.options_values_id = poval.products_options_values_id 
-                                and popt.language_id = '" . (int)$languages_id . "' 
-                                and poval.language_id = '" . (int)$languages_id . "'";
-          $attributes = tep_db_query($attributes_query);
-        } else {
-          $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . (int)$order->products[$i]['id'] . "' and pa.options_id = '" . (int)$order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . (int)$order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . (int)$languages_id . "' and poval.language_id = '" . (int)$languages_id . "'");
-        }
-        $attributes_values = tep_db_fetch_array($attributes);
-
-        $sql_data_array = array('orders_id' => $insert_id, 
-                                'orders_products_id' => $order_products_id, 
-                                'products_options' => $attributes_values['products_options_name'],
-                                'products_options_values' => $attributes_values['products_options_values_name'], 
-                                'options_values_price' => $attributes_values['options_values_price'], 
-                                'price_prefix' => $attributes_values['price_prefix']);
-        tep_db_perform('orders_products_attributes', $sql_data_array);
-
-        if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
-          $sql_data_array = array('orders_id' => $insert_id, 
-                                  'orders_products_id' => $order_products_id, 
-                                  'orders_products_filename' => $attributes_values['products_attributes_filename'], 
-                                  'download_maxdays' => $attributes_values['products_attributes_maxdays'], 
-                                  'download_count' => $attributes_values['products_attributes_maxcount']);
-          tep_db_perform('orders_products_download', $sql_data_array);
-        }
-        $products_ordered_attributes .= "\n\t" . $attributes_values['products_options_name'] . ' ' . $attributes_values['products_options_values_name'];
-      }
-    }
-//------insert customer choosen option eof ----
-    $products_ordered .= $order->products[$i]['qty'] . ' x ' . $order->products[$i]['name'] . (empty($order->products[$i]['model']) ? '' : ' (' . $order->products[$i]['model'] . ')') . ' = ' . $currencies->display_price($order->products[$i]['final_price'], $order->products[$i]['tax'], $order->products[$i]['qty']) . $products_ordered_attributes . "\n"; 
-  }
-
-// lets start with the email confirmation
-  $email_order = STORE_NAME . "\n" . 
-                 EMAIL_SEPARATOR . "\n" . 
-                 EMAIL_TEXT_ORDER_NUMBER . ' ' . $insert_id . "\n" .
-                 EMAIL_TEXT_INVOICE_URL . ' ' . tep_href_link('account_history_info.php', 'order_id=' . $insert_id, 'SSL', false) . "\n" .
-                 EMAIL_TEXT_DATE_ORDERED . ' ' . strftime(DATE_FORMAT_LONG) . "\n\n";
-  if ($order->info['comments']) {
-    $email_order .= tep_db_output($order->info['comments']) . "\n\n";
-  }
-  $email_order .= EMAIL_TEXT_PRODUCTS . "\n" . 
-                  EMAIL_SEPARATOR . "\n" . 
-                  $products_ordered . 
-                  EMAIL_SEPARATOR . "\n";
-
-  for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-    $email_order .= strip_tags($order_totals[$i]['title']) . ' ' . strip_tags($order_totals[$i]['text']) . "\n";
-  }
-
-  if ($order->content_type != 'virtual') {
-    $email_order .= "\n" . EMAIL_TEXT_DELIVERY_ADDRESS . "\n" . 
-                    EMAIL_SEPARATOR . "\n" .
-                    tep_address_label($customer_id, $sendto, 0, '', "\n") . "\n";
-  }
-
-  $email_order .= "\n" . EMAIL_TEXT_BILLING_ADDRESS . "\n" .
-                  EMAIL_SEPARATOR . "\n" .
-                  tep_address_label($customer_id, $billto, 0, '', "\n") . "\n\n";
-  if (is_object($$payment)) {
-    $email_order .= EMAIL_TEXT_PAYMENT_METHOD . "\n" . 
-                    EMAIL_SEPARATOR . "\n";
-    $payment_class = $$payment;
-    $email_order .= $order->info['payment_method'] . "\n\n";
-    if (isset($payment_class->email_footer)) {
-      $email_order .= $payment_class->email_footer . "\n\n";
-    }
-  }
-  tep_mail($order->customer['firstname'] . ' ' . $order->customer['lastname'], $order->customer['email_address'], EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-
-// send emails to other people
-  if (SEND_EXTRA_ORDER_EMAILS_TO != '') {
-    tep_mail('', SEND_EXTRA_ORDER_EMAILS_TO, EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-  }
+  tep_notify('checkout', $order);
 
 // load the after_process function from the payment modules
   $payment_modules->after_process();
 
-  $cart->reset(true);
-
-// unregister session variables used during checkout
-  tep_session_unregister('sendto');
-  tep_session_unregister('billto');
-  tep_session_unregister('shipping');
-  tep_session_unregister('payment');
-  tep_session_unregister('comments');
+  require 'includes/modules/checkout/reset.php';
 
   tep_redirect(tep_href_link('checkout_success.php', '', 'SSL'));
 
   require('includes/application_bottom.php');
-?>

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -240,6 +240,7 @@
 
       $this->customer = array('firstname' => $customer_address['customers_firstname'],
                               'lastname' => $customer_address['customers_lastname'],
+			      'name' => $customer_address['customers_firstname'] . ' ' . $customer_address['customers_lastname'],
                               'company' => $customer_address['entry_company'],
                               'street_address' => $customer_address['entry_street_address'],
                               'suburb' => $customer_address['entry_suburb'],
@@ -254,6 +255,7 @@
 
       $this->delivery = array('firstname' => $shipping_address['entry_firstname'],
                               'lastname' => $shipping_address['entry_lastname'],
+			      'name' => $shipping_address['entry_firstname'] . ' ' . $shipping_address['entry_lastname'],
                               'company' => $shipping_address['entry_company'],
                               'street_address' => $shipping_address['entry_street_address'],
                               'suburb' => $shipping_address['entry_suburb'],
@@ -267,6 +269,7 @@
 
       $this->billing = array('firstname' => $billing_address['entry_firstname'],
                              'lastname' => $billing_address['entry_lastname'],
+			     'name' => $billing_address['entry_firstname'] . ' ' . $billing_address['entry_lastname'],
                              'company' => $billing_address['entry_company'],
                              'street_address' => $billing_address['entry_street_address'],
                              'suburb' => $billing_address['entry_suburb'],
@@ -339,4 +342,3 @@
       }
     }
   }
-?>

--- a/includes/functions/general.php
+++ b/includes/functions/general.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2018 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */

--- a/includes/modules/checkout/build_order_totals.php
+++ b/includes/modules/checkout/build_order_totals.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ $Id$
+
+ osCommerce, Open Source E-Commerce Solutions
+ http://www.oscommerce.com
+
+ Copyright (c) 2019 osCommerce
+
+ Released under the GNU General Public License
+ */
+
+  $order_totals = [];
+  if (!is_array($GLOBALS['order_total_modules']->modules)) {
+    return;
+  }
+
+  foreach ($GLOBALS['order_total_modules']->modules as $value) {
+    $class = pathinfo($value, PATHINFO_FILENAME);
+    if (!$GLOBALS[$class]->enabled) {
+      continue;
+    }
+
+    foreach ($GLOBALS[$class]->output as $order_total) {
+      if (tep_not_null($order_total['title']) && tep_not_null($order_total['text'])) {
+        $order_totals[] = [
+          'code' => $GLOBALS[$class]->code,
+          'title' => $order_total['title'],
+          'text' => $order_total['text'],
+          'value' => $order_total['value'],
+          'sort_order' => $GLOBALS[$class]->sort_order,
+        ];
+      }
+    }
+  }

--- a/includes/modules/checkout/insert_order.php
+++ b/includes/modules/checkout/insert_order.php
@@ -8,7 +8,7 @@
  Copyright (c) 2019 osCommerce
 
  Released under the GNU General Public License
- */
+*/
 
   $sql_data = [
     'customers_id' => $customer_id,

--- a/includes/modules/checkout/insert_order.php
+++ b/includes/modules/checkout/insert_order.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ $Id$
+
+ osCommerce, Open Source E-Commerce Solutions
+ http://www.oscommerce.com
+
+ Copyright (c) 2019 osCommerce
+
+ Released under the GNU General Public License
+ */
+
+  $sql_data = [
+    'customers_id' => $customer_id,
+    'customers_name' => $order->customer['name'],
+    'customers_company' => $order->customer['company'],
+    'customers_street_address' => $order->customer['street_address'],
+    'customers_suburb' => $order->customer['suburb'],
+    'customers_city' => $order->customer['city'],
+    'customers_postcode' => $order->customer['postcode'],
+    'customers_state' => $order->customer['state'],
+    'customers_country' => $order->customer['country']['title'],
+    'customers_telephone' => $order->customer['telephone'],
+    'customers_email_address' => $order->customer['email_address'],
+    'customers_address_format_id' => $order->customer['format_id'],
+    'delivery_name' => $order->delivery['name'],
+    'delivery_company' => $order->delivery['company'],
+    'delivery_street_address' => $order->delivery['street_address'],
+    'delivery_suburb' => $order->delivery['suburb'],
+    'delivery_city' => $order->delivery['city'],
+    'delivery_postcode' => $order->delivery['postcode'],
+    'delivery_state' => $order->delivery['state'],
+    'delivery_country' => $order->delivery['country']['title'],
+    'delivery_address_format_id' => $order->delivery['format_id'],
+    'billing_name' => $order->billing['name'],
+    'billing_company' => $order->billing['company'],
+    'billing_street_address' => $order->billing['street_address'],
+    'billing_suburb' => $order->billing['suburb'],
+    'billing_city' => $order->billing['city'],
+    'billing_postcode' => $order->billing['postcode'],
+    'billing_state' => $order->billing['state'],
+    'billing_country' => $order->billing['country']['title'],
+    'billing_address_format_id' => $order->billing['format_id'],
+    'payment_method' => $order->info['payment_method'],
+    'cc_type' => $order->info['cc_type'],
+    'cc_owner' => $order->info['cc_owner'],
+    'cc_number' => $order->info['cc_number'],
+    'cc_expires' => $order->info['cc_expires'],
+    'date_purchased' => 'now()',
+    'orders_status' => $order->info['order_status'],
+    'currency' => $order->info['currency'],
+    'currency_value' => $order->info['currency_value'],
+  ];
+
+  tep_db_perform('orders', $sql_data);
+
+  $order_id = tep_db_insert_id();
+
+  foreach ($order_totals as $order_total) {
+    $sql_data = [
+      'orders_id' => $order_id,
+      'title' => $order_total['title'],
+      'text' => $order_total['text'],
+      'value' => $order_total['value'],
+      'class' => $order_total['code'],
+      'sort_order' => $order_total['sort_order'],
+    ];
+
+    tep_db_perform('orders_total', $sql_data);
+  }
+
+  foreach ($order->products as $product) {
+    $sql_data = [
+      'orders_id' => $order_id,
+      'products_id' => tep_get_prid($product['id']),
+      'products_model' => $product['model'],
+      'products_name' => $product['name'],
+      'products_price' => $product['price'],
+      'final_price' => $product['final_price'],
+      'products_tax' => $product['tax'],
+      'products_quantity' => $product['qty']];
+
+    tep_db_perform('orders_products', $sql_data);
+
+    $order_products_id = tep_db_insert_id();
+
+    if (isset($product['attributes'])) {
+      foreach ($product['attributes'] as $attribute) {
+        if (DOWNLOAD_ENABLED == 'true') {
+          $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
+                                     from products_options popt, products_options_values poval, products_attributes pa
+                                     left join products_attributes_download pad
+                                     on pa.products_attributes_id=pad.products_attributes_id
+                                     where pa.products_id = '" . $product['id'] . "'
+                                     and pa.options_id = '" . $attribute['option_id'] . "'
+                                     and pa.options_id = popt.products_options_id
+                                     and pa.options_values_id = '" . $attribute['value_id'] . "'
+                                     and pa.options_values_id = poval.products_options_values_id
+                                     and popt.language_id = '" . $languages_id . "'
+                                     and poval.language_id = '" . $languages_id . "'";
+          $attributes = tep_db_query($attributes_query);
+        } else {
+          $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . $product['id'] . "' and pa.options_id = '" . $attribute['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $attribute['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
+        }
+        $attributes_values = tep_db_fetch_array($attributes);
+
+        $sql_data = [
+          'orders_id' => $order_id,
+          'orders_products_id' => $order_products_id,
+          'products_options' => $attributes_values['products_options_name'],
+          'products_options_values' => $attributes_values['products_options_values_name'],
+          'options_values_price' => $attributes_values['options_values_price'],
+          'price_prefix' => $attributes_values['price_prefix'],
+        ];
+
+        tep_db_perform('orders_products_attributes', $sql_data);
+
+        if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
+          $sql_data = [
+            'orders_id' => $order_id,
+            'orders_products_id' => $order_products_id,
+            'orders_products_filename' => $attributes_values['products_attributes_filename'],
+            'download_maxdays' => $attributes_values['products_attributes_maxdays'],
+            'download_count' => $attributes_values['products_attributes_maxcount'],
+          ];
+
+          tep_db_perform('orders_products_download', $sql_data);
+        }
+      }
+    }
+  }

--- a/includes/modules/checkout/reset.php
+++ b/includes/modules/checkout/reset.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ $Id$
+
+ osCommerce, Open Source E-Commerce Solutions
+ http://www.oscommerce.com
+
+ Copyright (c) 2019 osCommerce
+
+ Released under the GNU General Public License
+*/
+
+  $GLOBALS['cart']->reset(true);
+
+  // unregister session variables used during checkout
+  tep_session_unregister('sendto');
+  tep_session_unregister('billto');
+  tep_session_unregister('shipping');
+  tep_session_unregister('payment');
+  tep_session_unregister('comments');

--- a/includes/modules/payment/authorizenet_cc_dpm.php
+++ b/includes/modules/payment/authorizenet_cc_dpm.php
@@ -11,7 +11,20 @@
 */
 
   class authorizenet_cc_dpm {
-    var $code, $title, $description, $enabled;
+
+    const REQUIRES = [
+      'firstname',
+      'lastname',
+      'street_address',
+      'city',
+      'postcode',
+      'country',
+      'telephone',
+      'email_address',
+    ];
+
+    public $code = 'authorizenet_cc_dpm';
+    public $title, $description, $enabled;
 
     function __construct() {
       global $order;
@@ -19,7 +32,6 @@
       $this->signature = 'authorizenet|authorizenet_cc_dpm|1.0|2.3';
       $this->api_version = '3.1';
 
-      $this->code = 'authorizenet_cc_dpm';
       $this->title = MODULE_PAYMENT_AUTHORIZENET_CC_DPM_TEXT_TITLE;
       $this->public_title = MODULE_PAYMENT_AUTHORIZENET_CC_DPM_TEXT_PUBLIC_TITLE;
       $this->description = MODULE_PAYMENT_AUTHORIZENET_CC_DPM_TEXT_DESCRIPTION;
@@ -263,7 +275,7 @@ EOD;
     }
 
     function after_process() {
-      global $insert_id;
+      global $order_id;
 
       $response = array('Response: ' . tep_db_prepare_input($_POST['x_response_reason_text']) . ' (' . tep_db_prepare_input($_POST['x_response_reason_code']) . ')',
                         'Transaction ID: ' . tep_db_prepare_input($_POST['x_trans_id']));
@@ -304,7 +316,7 @@ EOD;
 
       $response[] = 'Card Holder: ' . tep_db_prepare_input($cavv_response);
 
-      $sql_data_array = array('orders_id' => $insert_id,
+      $sql_data_array = array('orders_id' => $order_id,
                               'orders_status_id' => MODULE_PAYMENT_AUTHORIZENET_CC_DPM_TRANSACTION_ORDER_STATUS_ID,
                               'date_added' => 'now()',
                               'customer_notified' => '0',
@@ -313,16 +325,7 @@ EOD;
       tep_db_perform('orders_status_history', $sql_data_array);
 
       if ( ENABLE_SSL != true ) {
-        global $cart;
-
-        $cart->reset(true);
-
-// unregister session variables used during checkout
-        tep_session_unregister('sendto');
-        tep_session_unregister('billto');
-        tep_session_unregister('shipping');
-        tep_session_unregister('payment');
-        tep_session_unregister('comments');
+        require 'includes/modules/checkout/reset.php';
 
         $redirect_url = tep_href_link('checkout_success.php', '', 'SSL');
 

--- a/includes/modules/payment/authorizenet_cc_dpm.php
+++ b/includes/modules/payment/authorizenet_cc_dpm.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */

--- a/includes/modules/payment/authorizenet_cc_sim.php
+++ b/includes/modules/payment/authorizenet_cc_sim.php
@@ -5,13 +5,26 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
 
   class authorizenet_cc_sim {
-    var $code, $title, $description, $enabled;
+
+    const REQUIRES = [
+      'firstname',
+      'lastname',
+      'street_address',
+      'city',
+      'postcode',
+      'country',
+      'telephone',
+      'email_address',
+    ];
+
+    public $code = 'authorizenet_cc_sim';
+    public $title, $description, $enabled;
 
     function __construct() {
       global $order;
@@ -19,7 +32,6 @@
       $this->signature = 'authorizenet|authorizenet_cc_sim|2.0|2.3';
       $this->api_version = '3.1';
 
-      $this->code = 'authorizenet_cc_sim';
       $this->title = MODULE_PAYMENT_AUTHORIZENET_CC_SIM_TEXT_TITLE;
       $this->public_title = MODULE_PAYMENT_AUTHORIZENET_CC_SIM_TEXT_PUBLIC_TITLE;
       $this->description = MODULE_PAYMENT_AUTHORIZENET_CC_SIM_TEXT_DESCRIPTION;
@@ -225,7 +237,7 @@
     }
 
     function after_process() {
-      global $insert_id;
+      global $order_id;
 
       $response = array('Response: ' . tep_db_prepare_input($_POST['x_response_reason_text']) . ' (' . tep_db_prepare_input($_POST['x_response_reason_code']) . ')',
                         'Transaction ID: ' . tep_db_prepare_input($_POST['x_trans_id']));
@@ -266,7 +278,7 @@
 
       $response[] = 'Card Holder: ' . tep_db_prepare_input($cavv_response);
 
-      $sql_data_array = array('orders_id' => $insert_id,
+      $sql_data_array = array('orders_id' => $order_id,
                               'orders_status_id' => MODULE_PAYMENT_AUTHORIZENET_CC_SIM_TRANSACTION_ORDER_STATUS_ID,
                               'date_added' => 'now()',
                               'customer_notified' => '0',
@@ -275,16 +287,7 @@
       tep_db_perform('orders_status_history', $sql_data_array);
 
       if ( ENABLE_SSL != true ) {
-        global $cart;
-
-        $cart->reset(true);
-
-// unregister session variables used during checkout
-        tep_session_unregister('sendto');
-        tep_session_unregister('billto');
-        tep_session_unregister('shipping');
-        tep_session_unregister('payment');
-        tep_session_unregister('comments');
+        require 'includes/modules/checkout/reset.php';
 
         $redirect_url = tep_href_link('checkout_success.php', '', 'SSL');
 

--- a/includes/modules/payment/paypal_pro_hs.php
+++ b/includes/modules/payment/paypal_pro_hs.php
@@ -15,7 +15,20 @@
   }
 
   class paypal_pro_hs {
-    var $code, $title, $description, $enabled, $_app;
+
+    const REQUIRES = [
+      'firstname',
+      'lastname',
+      'street_address',
+      'city',
+      'postcode',
+      'country',
+      'telephone',
+      'email_address',
+    ];
+
+    public $code = 'paypal_pro_hs';
+    public $title, $description, $enabled, $_app;
 
     function __construct() {
       global $order;
@@ -26,7 +39,6 @@
       $this->signature = 'paypal|paypal_pro_hs|' . $this->_app->getVersion() . '|2.3';
       $this->api_version = $this->_app->getApiVersion();
 
-      $this->code = 'paypal_pro_hs';
       $this->title = $this->_app->getDef('module_hs_title');
       $this->public_title = $this->_app->getDef('module_hs_public_title');
       $this->description = '<div align="center">' . $this->_app->drawButton($this->_app->getDef('module_hs_legacy_admin_app_button'), tep_href_link('paypal.php', 'action=configure&module=HS'), 'primary', null, true) . '</div>';
@@ -107,12 +119,7 @@
         $check_query = tep_db_query('select orders_id from orders_status_history where orders_id = "' . (int)$order_id . '" limit 1');
 
         if (tep_db_num_rows($check_query) < 1) {
-          tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
+          tep_delete_order($order_id);
 
           tep_session_unregister('cart_PayPal_Pro_HS_ID');
         }
@@ -152,12 +159,7 @@
             $check_query = tep_db_query('select orders_id from orders_status_history where orders_id = "' . (int)$order_id . '" limit 1');
 
             if (tep_db_num_rows($check_query) < 1) {
-              tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
+              tep_delete_order($order_id);
             }
 
             $insert_order = true;
@@ -167,150 +169,22 @@
         }
 
         if ($insert_order == true) {
-          $order_totals = array();
-          if (is_array($order_total_modules->modules)) {
-            foreach ($order_total_modules->modules as $value) {
-              $class = substr($value, 0, strrpos($value, '.'));
-              if ($GLOBALS[$class]->enabled) {
-                for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
-                  if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
-                    $order_totals[] = array('code' => $GLOBALS[$class]->code,
-                                            'title' => $GLOBALS[$class]->output[$i]['title'],
-                                            'text' => $GLOBALS[$class]->output[$i]['text'],
-                                            'value' => $GLOBALS[$class]->output[$i]['value'],
-                                            'sort_order' => $GLOBALS[$class]->sort_order);
-                  }
-                }
-              }
-            }
-          }
+          require 'includes/modules/checkout/build_order_totals.php';
+          require 'includes/modules/checkout/insert_order.php';
 
-          $sql_data_array = array('customers_id' => $customer_id,
-                                  'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
-                                  'customers_company' => $order->customer['company'],
-                                  'customers_street_address' => $order->customer['street_address'],
-                                  'customers_suburb' => $order->customer['suburb'],
-                                  'customers_city' => $order->customer['city'],
-                                  'customers_postcode' => $order->customer['postcode'],
-                                  'customers_state' => $order->customer['state'],
-                                  'customers_country' => $order->customer['country']['title'],
-                                  'customers_telephone' => $order->customer['telephone'],
-                                  'customers_email_address' => $order->customer['email_address'],
-                                  'customers_address_format_id' => $order->customer['format_id'],
-                                  'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
-                                  'delivery_company' => $order->delivery['company'],
-                                  'delivery_street_address' => $order->delivery['street_address'],
-                                  'delivery_suburb' => $order->delivery['suburb'],
-                                  'delivery_city' => $order->delivery['city'],
-                                  'delivery_postcode' => $order->delivery['postcode'],
-                                  'delivery_state' => $order->delivery['state'],
-                                  'delivery_country' => $order->delivery['country']['title'],
-                                  'delivery_address_format_id' => $order->delivery['format_id'],
-                                  'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
-                                  'billing_company' => $order->billing['company'],
-                                  'billing_street_address' => $order->billing['street_address'],
-                                  'billing_suburb' => $order->billing['suburb'],
-                                  'billing_city' => $order->billing['city'],
-                                  'billing_postcode' => $order->billing['postcode'],
-                                  'billing_state' => $order->billing['state'],
-                                  'billing_country' => $order->billing['country']['title'],
-                                  'billing_address_format_id' => $order->billing['format_id'],
-                                  'payment_method' => $order->info['payment_method'],
-                                  'cc_type' => $order->info['cc_type'],
-                                  'cc_owner' => $order->info['cc_owner'],
-                                  'cc_number' => $order->info['cc_number'],
-                                  'cc_expires' => $order->info['cc_expires'],
-                                  'date_purchased' => 'now()',
-                                  'orders_status' => $order->info['order_status'],
-                                  'currency' => $order->info['currency'],
-                                  'currency_value' => $order->info['currency_value']);
-
-          tep_db_perform('orders', $sql_data_array);
-
-          $insert_id = tep_db_insert_id();
-
-          for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'title' => $order_totals[$i]['title'],
-                                    'text' => $order_totals[$i]['text'],
-                                    'value' => $order_totals[$i]['value'],
-                                    'class' => $order_totals[$i]['code'],
-                                    'sort_order' => $order_totals[$i]['sort_order']);
-
-            tep_db_perform('orders_total', $sql_data_array);
-          }
-
-          for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'products_id' => tep_get_prid($order->products[$i]['id']),
-                                    'products_model' => $order->products[$i]['model'],
-                                    'products_name' => $order->products[$i]['name'],
-                                    'products_price' => $order->products[$i]['price'],
-                                    'final_price' => $order->products[$i]['final_price'],
-                                    'products_tax' => $order->products[$i]['tax'],
-                                    'products_quantity' => $order->products[$i]['qty']);
-
-            tep_db_perform('orders_products', $sql_data_array);
-
-            $order_products_id = tep_db_insert_id();
-
-            $attributes_exist = '0';
-            if (isset($order->products[$i]['attributes'])) {
-              $attributes_exist = '1';
-              for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-                if (DOWNLOAD_ENABLED == 'true') {
-                  $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                       from products_options popt, products_options_values poval, products_attributes pa
-                                       left join products_attributes_download pad
-                                       on pa.products_attributes_id=pad.products_attributes_id
-                                       where pa.products_id = '" . $order->products[$i]['id'] . "'
-                                       and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
-                                       and pa.options_id = popt.products_options_id
-                                       and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
-                                       and pa.options_values_id = poval.products_options_values_id
-                                       and popt.language_id = '" . $languages_id . "'
-                                       and poval.language_id = '" . $languages_id . "'";
-                  $attributes = tep_db_query($attributes_query);
-                } else {
-                  $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
-                }
-                $attributes_values = tep_db_fetch_array($attributes);
-
-                $sql_data_array = array('orders_id' => $insert_id,
-                                        'orders_products_id' => $order_products_id,
-                                        'products_options' => $attributes_values['products_options_name'],
-                                        'products_options_values' => $attributes_values['products_options_values_name'],
-                                        'options_values_price' => $attributes_values['options_values_price'],
-                                        'price_prefix' => $attributes_values['price_prefix']);
-
-                tep_db_perform('orders_products_attributes', $sql_data_array);
-
-                if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
-                  $sql_data_array = array('orders_id' => $insert_id,
-                                          'orders_products_id' => $order_products_id,
-                                          'orders_products_filename' => $attributes_values['products_attributes_filename'],
-                                          'download_maxdays' => $attributes_values['products_attributes_maxdays'],
-                                          'download_count' => $attributes_values['products_attributes_maxcount']);
-
-                  tep_db_perform('orders_products_download', $sql_data_array);
-                }
-              }
-            }
-          }
-
-          $cart_PayPal_Pro_HS_ID = $cartID . '-' . $insert_id;
+          $cart_PayPal_Pro_HS_ID = $cartID . '-' . $order_id;
           tep_session_register('cart_PayPal_Pro_HS_ID');
         }
 
         $order_id = substr($cart_PayPal_Pro_HS_ID, strpos($cart_PayPal_Pro_HS_ID, '-')+1);
 
         $params = array('buyer_email' => $order->customer['email_address'],
-                        'cancel_return' => tep_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'),
+                        'cancel_return' => tep_href_link('checkout_payment.php', '', 'SSL'),
                         'currency_code' => $currency,
                         'invoice' => $order_id,
                         'custom' => $customer_id,
                         'paymentaction' => OSCOM_APP_PAYPAL_HS_TRANSACTION_METHOD == '1' ? 'sale' : 'authorization',
-                        'return' => tep_href_link(FILENAME_CHECKOUT_PROCESS, '', 'SSL'),
+                        'return' => tep_href_link('checkout_process.php', '', 'SSL'),
                         'notify_url' => tep_href_link('ext/modules/payment/paypal/pro_hosted_ipn.php', '', 'SSL', false, false),
                         'shipping' => $this->_app->formatCurrencyRaw($order->info['shipping_cost']),
                         'tax' => $this->_app->formatCurrencyRaw($order->info['tax']),
@@ -362,7 +236,7 @@
       }
 
       $iframe_url = tep_href_link('ext/modules/payment/paypal/hosted_checkout.php', 'key=' . $pphs_key, 'SSL');
-      $form_url = tep_href_link(FILENAME_CHECKOUT_PAYMENT, 'payment_error=paypal_pro_hs', 'SSL');
+      $form_url = tep_href_link('checkout_payment.php', 'payment_error=paypal_pro_hs', 'SSL');
 
 // include jquery if it doesn't exist in the template
       $output = <<<EOD
@@ -402,7 +276,7 @@ EOD;
       }
 
       if ( !in_array($result['ACK'], array('Success', 'SuccessWithWarning')) ) {
-        tep_redirect(tep_href_link(FILENAME_SHOPPING_CART, 'error_message=' . stripslashes($result['L_LONGMESSAGE0'])));
+        tep_redirect(tep_href_link('shopping_cart.php', 'error_message=' . stripslashes($result['L_LONGMESSAGE0'])));
       }
 
       $order_id = substr($cart_PayPal_Pro_HS_ID, strpos($cart_PayPal_Pro_HS_ID, '-')+1);
@@ -414,7 +288,7 @@ EOD;
       }
 
       if ( !isset($result['RECEIVERBUSINESS']) || !in_array($result['RECEIVERBUSINESS'], $seller_accounts) || ($result['INVNUM'] != $order_id) || ($result['CUSTOM'] != $customer_id) ) {
-        tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
+        tep_redirect(tep_href_link('shopping_cart.php'));
       }
 
       $pphs_result = $result;
@@ -425,7 +299,7 @@ EOD;
       $tx_customer_id = $pphs_result['CUSTOM'];
 
       if (!tep_db_num_rows($check_query) || ($order_id != $tx_order_id) || ($customer_id != $tx_customer_id)) {
-        tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
+        tep_redirect(tep_href_link('shopping_cart.php'));
       }
 
       $check = tep_db_fetch_array($check_query);
@@ -452,147 +326,18 @@ EOD;
 
       tep_db_perform('orders_status_history', $sql_data_array);
 
-// initialized for the email confirmation
-      $products_ordered = '';
-      $subtotal = 0;
-      $total_tax = 0;
-
-      for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-// Stock Update - Joao Correia
-        if (STOCK_LIMITED == 'true') {
-          if (DOWNLOAD_ENABLED == 'true') {
-            $stock_query_raw = "SELECT products_quantity, pad.products_attributes_filename
-                                FROM products p
-                                LEFT JOIN products_attributes pa
-                                ON p.products_id=pa.products_id
-                                LEFT JOIN products_attributes_download pad
-                                ON pa.products_attributes_id=pad.products_attributes_id
-                                WHERE p.products_id = '" . tep_get_prid($order->products[$i]['id']) . "'";
-// Will work with only one option for downloadable products
-// otherwise, we have to build the query dynamically with a loop
-            $products_attributes = $order->products[$i]['attributes'];
-            if (is_array($products_attributes)) {
-              $stock_query_raw .= " AND pa.options_id = '" . $products_attributes[0]['option_id'] . "' AND pa.options_values_id = '" . $products_attributes[0]['value_id'] . "'";
-            }
-            $stock_query = tep_db_query($stock_query_raw);
-          } else {
-            $stock_query = tep_db_query("select products_quantity from products where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-          }
-          if (tep_db_num_rows($stock_query) > 0) {
-            $stock_values = tep_db_fetch_array($stock_query);
-// do not decrement quantities if products_attributes_filename exists
-            if ((DOWNLOAD_ENABLED != 'true') || (!$stock_values['products_attributes_filename'])) {
-              $stock_left = $stock_values['products_quantity'] - $order->products[$i]['qty'];
-            } else {
-              $stock_left = $stock_values['products_quantity'];
-            }
-            tep_db_query("update products set products_quantity = '" . $stock_left . "' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-            if ( ($stock_left < 1) && (STOCK_ALLOW_CHECKOUT == 'false') ) {
-              tep_db_query("update products set products_status = '0' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-            }
-          }
-        }
-
-// Update products_ordered (for bestsellers list)
-        tep_db_query("update products set products_ordered = products_ordered + " . sprintf('%d', $order->products[$i]['qty']) . " where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-
-//------insert customer choosen option to order--------
-        $attributes_exist = '0';
-        $products_ordered_attributes = '';
-        if (isset($order->products[$i]['attributes'])) {
-          $attributes_exist = '1';
-          for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-            if (DOWNLOAD_ENABLED == 'true') {
-              $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                   from products_options popt, products_options_values poval, products_attributes pa
-                                   left join products_attributes_download pad
-                                   on pa.products_attributes_id=pad.products_attributes_id
-                                   where pa.products_id = '" . $order->products[$i]['id'] . "'
-                                   and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
-                                   and pa.options_id = popt.products_options_id
-                                   and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
-                                   and pa.options_values_id = poval.products_options_values_id
-                                   and popt.language_id = '" . $languages_id . "'
-                                   and poval.language_id = '" . $languages_id . "'";
-              $attributes = tep_db_query($attributes_query);
-            } else {
-              $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
-            }
-            $attributes_values = tep_db_fetch_array($attributes);
-
-            $products_ordered_attributes .= "\n\t" . $attributes_values['products_options_name'] . ' ' . $attributes_values['products_options_values_name'];
-          }
-        }
-//------insert customer choosen option eof ----
-        $total_weight += ($order->products[$i]['qty'] * $order->products[$i]['weight']);
-        $total_tax += tep_calculate_tax($total_products_price, $products_tax) * $order->products[$i]['qty'];
-        $total_cost += $total_products_price;
-
-        $products_ordered .= $order->products[$i]['qty'] . ' x ' . $order->products[$i]['name'] . ' (' . $order->products[$i]['model'] . ') = ' . $currencies->display_price($order->products[$i]['final_price'], $order->products[$i]['tax'], $order->products[$i]['qty']) . $products_ordered_attributes . "\n";
-      }
-
-// lets start with the email confirmation
-      $email_order = STORE_NAME . "\n" .
-                     EMAIL_SEPARATOR . "\n" .
-                     EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_id . "\n" .
-                     EMAIL_TEXT_INVOICE_URL . ' ' . tep_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $order_id, 'SSL', false) . "\n" .
-                     EMAIL_TEXT_DATE_ORDERED . ' ' . strftime(DATE_FORMAT_LONG) . "\n\n";
-      if ($order->info['comments']) {
-        $email_order .= tep_db_output($order->info['comments']) . "\n\n";
-      }
-      $email_order .= EMAIL_TEXT_PRODUCTS . "\n" .
-                      EMAIL_SEPARATOR . "\n" .
-                      $products_ordered .
-                      EMAIL_SEPARATOR . "\n";
-
-      for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-        $email_order .= strip_tags($order_totals[$i]['title']) . ' ' . strip_tags($order_totals[$i]['text']) . "\n";
-      }
-
-      if ($order->content_type != 'virtual') {
-        $email_order .= "\n" . EMAIL_TEXT_DELIVERY_ADDRESS . "\n" .
-                        EMAIL_SEPARATOR . "\n" .
-                        tep_address_label($customer_id, $sendto, 0, '', "\n") . "\n";
-      }
-
-      $email_order .= "\n" . EMAIL_TEXT_BILLING_ADDRESS . "\n" .
-                      EMAIL_SEPARATOR . "\n" .
-                      tep_address_label($customer_id, $billto, 0, '', "\n") . "\n\n";
-
-      if (is_object($$payment)) {
-        $email_order .= EMAIL_TEXT_PAYMENT_METHOD . "\n" .
-                        EMAIL_SEPARATOR . "\n";
-        $payment_class = $$payment;
-        $email_order .= $payment_class->title . "\n\n";
-        if ($payment_class->email_footer) {
-          $email_order .= $payment_class->email_footer . "\n\n";
-        }
-      }
-
-      tep_mail($order->customer['firstname'] . ' ' . $order->customer['lastname'], $order->customer['email_address'], EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-
-// send emails to other people
-      if (SEND_EXTRA_ORDER_EMAILS_TO != '') {
-        tep_mail('', SEND_EXTRA_ORDER_EMAILS_TO, EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-      }
+      tep_notify('checkout', $order);
 
 // load the after_process function from the payment modules
       $this->after_process();
 
-      $cart->reset(true);
-
-// unregister session variables used during checkout
-      tep_session_unregister('sendto');
-      tep_session_unregister('billto');
-      tep_session_unregister('shipping');
-      tep_session_unregister('payment');
-      tep_session_unregister('comments');
+      require 'includes/modules/checkout/reset.php';
 
       tep_session_unregister('cart_PayPal_Pro_HS_ID');
       tep_session_unregister('pphs_result');
       tep_session_unregister('pphs_key');
 
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SUCCESS, '', 'SSL'));
+      tep_redirect(tep_href_link('checkout_success.php', '', 'SSL'));
     }
 
     function after_process() {

--- a/includes/modules/payment/paypal_standard.php
+++ b/includes/modules/payment/paypal_standard.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2017 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
@@ -15,7 +15,20 @@
   }
 
   class paypal_standard {
-    var $code, $title, $description, $enabled, $_app;
+
+    const REQUIRES = [
+      'firstname',
+      'lastname',
+      'street_address',
+      'city',
+      'postcode',
+      'country',
+      'telephone',
+      'email_address',
+    ];
+
+    public $code = 'paypal_standard';
+    public $title, $description, $enabled, $_app;
 
     function __construct() {
       global $PHP_SELF, $payment, $order;
@@ -26,7 +39,6 @@
       $this->signature = 'paypal|paypal_standard|' . $this->_app->getVersion() . '|2.3';
       $this->api_version = $this->_app->getApiVersion();
 
-      $this->code = 'paypal_standard';
       $this->title = $this->_app->getDef('module_ps_title');
       $this->public_title = $this->_app->getDef('module_ps_public_title');
       $this->description = '<div align="center">' . $this->_app->drawButton($this->_app->getDef('module_ps_legacy_admin_app_button'), tep_href_link('paypal.php', 'action=configure&module=PS'), 'primary', null, true) . '</div>';
@@ -76,9 +88,9 @@
       }
 
 // Before the stock quantity check is performed in checkout_process.php, detect if the quantity
-// has already beed deducated in the IPN to avoid a quantity == 0 redirect
+// has already been deducted in the IPN to avoid a quantity == 0 redirect
       if ( $this->enabled === true ) {
-        if ( defined('FILENAME_CHECKOUT_PROCESS') && (basename($PHP_SELF) == FILENAME_CHECKOUT_PROCESS) ) {
+        if (basename($PHP_SELF) == 'checkout_process.php') {
           if ( tep_session_is_registered('payment') && ($payment == $this->code) ) {
             $this->pre_before_check();
           }
@@ -121,12 +133,7 @@
         $check_query = tep_db_query('select orders_id from orders_status_history where orders_id = "' . (int)$order_id . '" limit 1');
 
         if (tep_db_num_rows($check_query) < 1) {
-          tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
+          tep_delete_order($order_id);
 
           tep_session_unregister('cart_PayPal_Standard_ID');
         }
@@ -167,12 +174,7 @@
             $check_query = tep_db_query('select orders_id from orders_status_history where orders_id = "' . (int)$order_id . '" limit 1');
 
             if (tep_db_num_rows($check_query) < 1) {
-              tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
+              tep_delete_order($order_id);
             }
 
             $insert_order = true;
@@ -182,143 +184,10 @@
         }
 
         if ($insert_order == true) {
-          $order_totals = array();
-          if (is_array($order_total_modules->modules)) {
-            foreach ($order_total_modules->modules as $value) {
-              $class = substr($value, 0, strrpos($value, '.'));
-              if ($GLOBALS[$class]->enabled) {
-                for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
-                  if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
-                    $order_totals[] = array('code' => $GLOBALS[$class]->code,
-                                            'title' => $GLOBALS[$class]->output[$i]['title'],
-                                            'text' => $GLOBALS[$class]->output[$i]['text'],
-                                            'value' => $GLOBALS[$class]->output[$i]['value'],
-                                            'sort_order' => $GLOBALS[$class]->sort_order);
-                  }
-                }
-              }
-            }
-          }
+          require 'includes/modules/checkout/build_order_totals.php';
+          require 'includes/modules/checkout/insert_order.php';
 
-          if ( isset($order->info['payment_method_raw']) ) {
-            $order->info['payment_method'] = $order->info['payment_method_raw'];
-            unset($order->info['payment_method_raw']);
-          }
-
-          $sql_data_array = array('customers_id' => $customer_id,
-                                  'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
-                                  'customers_company' => $order->customer['company'],
-                                  'customers_street_address' => $order->customer['street_address'],
-                                  'customers_suburb' => $order->customer['suburb'],
-                                  'customers_city' => $order->customer['city'],
-                                  'customers_postcode' => $order->customer['postcode'],
-                                  'customers_state' => $order->customer['state'],
-                                  'customers_country' => $order->customer['country']['title'],
-                                  'customers_telephone' => $order->customer['telephone'],
-                                  'customers_email_address' => $order->customer['email_address'],
-                                  'customers_address_format_id' => $order->customer['format_id'],
-                                  'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
-                                  'delivery_company' => $order->delivery['company'],
-                                  'delivery_street_address' => $order->delivery['street_address'],
-                                  'delivery_suburb' => $order->delivery['suburb'],
-                                  'delivery_city' => $order->delivery['city'],
-                                  'delivery_postcode' => $order->delivery['postcode'],
-                                  'delivery_state' => $order->delivery['state'],
-                                  'delivery_country' => $order->delivery['country']['title'],
-                                  'delivery_address_format_id' => $order->delivery['format_id'],
-                                  'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
-                                  'billing_company' => $order->billing['company'],
-                                  'billing_street_address' => $order->billing['street_address'],
-                                  'billing_suburb' => $order->billing['suburb'],
-                                  'billing_city' => $order->billing['city'],
-                                  'billing_postcode' => $order->billing['postcode'],
-                                  'billing_state' => $order->billing['state'],
-                                  'billing_country' => $order->billing['country']['title'],
-                                  'billing_address_format_id' => $order->billing['format_id'],
-                                  'payment_method' => $order->info['payment_method'],
-                                  'cc_type' => $order->info['cc_type'],
-                                  'cc_owner' => $order->info['cc_owner'],
-                                  'cc_number' => $order->info['cc_number'],
-                                  'cc_expires' => $order->info['cc_expires'],
-                                  'date_purchased' => 'now()',
-                                  'orders_status' => $order->info['order_status'],
-                                  'currency' => $order->info['currency'],
-                                  'currency_value' => $order->info['currency_value']);
-
-          tep_db_perform('orders', $sql_data_array);
-
-          $insert_id = tep_db_insert_id();
-
-          for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'title' => $order_totals[$i]['title'],
-                                    'text' => $order_totals[$i]['text'],
-                                    'value' => $order_totals[$i]['value'],
-                                    'class' => $order_totals[$i]['code'],
-                                    'sort_order' => $order_totals[$i]['sort_order']);
-
-            tep_db_perform('orders_total', $sql_data_array);
-          }
-
-          for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'products_id' => tep_get_prid($order->products[$i]['id']),
-                                    'products_model' => $order->products[$i]['model'],
-                                    'products_name' => $order->products[$i]['name'],
-                                    'products_price' => $order->products[$i]['price'],
-                                    'final_price' => $order->products[$i]['final_price'],
-                                    'products_tax' => $order->products[$i]['tax'],
-                                    'products_quantity' => $order->products[$i]['qty']);
-
-            tep_db_perform('orders_products', $sql_data_array);
-
-            $order_products_id = tep_db_insert_id();
-
-            $attributes_exist = '0';
-            if (isset($order->products[$i]['attributes'])) {
-              $attributes_exist = '1';
-              for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-                if (DOWNLOAD_ENABLED == 'true') {
-                  $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                       from products_options popt, products_options_values poval, products_attributes pa
-                                       left join products_attributes_download pad
-                                       on pa.products_attributes_id=pad.products_attributes_id
-                                       where pa.products_id = '" . (int)$order->products[$i]['id'] . "'
-                                       and pa.options_id = '" . (int)$order->products[$i]['attributes'][$j]['option_id'] . "'
-                                       and pa.options_id = popt.products_options_id
-                                       and pa.options_values_id = '" . (int)$order->products[$i]['attributes'][$j]['value_id'] . "'
-                                       and pa.options_values_id = poval.products_options_values_id
-                                       and popt.language_id = '" . (int)$languages_id . "'
-                                       and poval.language_id = '" . (int)$languages_id . "'";
-                  $attributes = tep_db_query($attributes_query);
-                } else {
-                  $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . (int)$order->products[$i]['id'] . "' and pa.options_id = '" . (int)$order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . (int)$order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . (int)$languages_id . "' and poval.language_id = '" . (int)$languages_id . "'");
-                }
-                $attributes_values = tep_db_fetch_array($attributes);
-
-                $sql_data_array = array('orders_id' => $insert_id,
-                                        'orders_products_id' => $order_products_id,
-                                        'products_options' => $attributes_values['products_options_name'],
-                                        'products_options_values' => $attributes_values['products_options_values_name'],
-                                        'options_values_price' => $attributes_values['options_values_price'],
-                                        'price_prefix' => $attributes_values['price_prefix']);
-
-                tep_db_perform('orders_products_attributes', $sql_data_array);
-
-                if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
-                  $sql_data_array = array('orders_id' => $insert_id,
-                                          'orders_products_id' => $order_products_id,
-                                          'orders_products_filename' => $attributes_values['products_attributes_filename'],
-                                          'download_maxdays' => $attributes_values['products_attributes_maxdays'],
-                                          'download_count' => $attributes_values['products_attributes_maxcount']);
-
-                  tep_db_perform('orders_products_download', $sql_data_array);
-                }
-              }
-            }
-          }
-
-          $cart_PayPal_Standard_ID = $cartID . '-' . $insert_id;
+          $cart_PayPal_Standard_ID = $cartID . '-' . $order_id;
           tep_session_register('cart_PayPal_Standard_ID');
         }
       }
@@ -365,8 +234,8 @@
                           'custom' => $customer_id,
                           'notify_url' => tep_href_link('ext/modules/payment/paypal/standard_ipn.php', (isset($ipn_language) ? 'language=' . $ipn_language : ''), 'SSL', false, false),
                           'rm' => '2',
-                          'return' => tep_href_link(FILENAME_CHECKOUT_PROCESS, '', 'SSL'),
-                          'cancel_return' => tep_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'),
+                          'return' => tep_href_link('checkout_process.php', '', 'SSL'),
+                          'cancel_return' => tep_href_link('checkout_payment.php', '', 'SSL'),
                           'bn' => $this->_app->getIdentifier(),
                           'paymentaction' => (OSCOM_APP_PAYPAL_PS_TRANSACTION_METHOD == '1') ? 'sale' : 'authorization');
 
@@ -635,7 +504,7 @@
       if ( $result != 'VERIFIED' ) {
         $messageStack->add_session('header', $this->_app->getDef('module_ps_error_invalid_transaction'));
 
-        tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
+        tep_redirect(tep_href_link('shopping_cart.php'));
       }
 
       $this->verifyTransaction($pptx_params);
@@ -645,7 +514,7 @@
       $check_query = tep_db_query("select orders_status from orders where orders_id = '" . (int)$order_id . "' and customers_id = '" . (int)$customer_id . "'");
 
       if (!tep_db_num_rows($check_query) || ($order_id != $pptx_params['invoice']) || ($customer_id != $pptx_params['custom'])) {
-        tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
+        tep_redirect(tep_href_link('shopping_cart.php'));
       }
 
       $check = tep_db_fetch_array($check_query);
@@ -686,143 +555,18 @@
 
       tep_db_perform('orders_status_history', $sql_data_array);
 
-// initialized for the email confirmation
-      $products_ordered = '';
-
-      for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-// Stock Update - Joao Correia
-        if (STOCK_LIMITED == 'true') {
-          if (DOWNLOAD_ENABLED == 'true') {
-            $stock_query_raw = "SELECT products_quantity, pad.products_attributes_filename
-                                FROM products p
-                                LEFT JOIN products_attributes pa
-                                ON p.products_id=pa.products_id
-                                LEFT JOIN products_attributes_download pad
-                                ON pa.products_attributes_id=pad.products_attributes_id
-                                WHERE p.products_id = '" . tep_get_prid($order->products[$i]['id']) . "'";
-// Will work with only one option for downloadable products
-// otherwise, we have to build the query dynamically with a loop
-            $products_attributes = (isset($order->products[$i]['attributes'])) ? $order->products[$i]['attributes'] : '';
-            if (is_array($products_attributes)) {
-              $stock_query_raw .= " AND pa.options_id = '" . (int)$products_attributes[0]['option_id'] . "' AND pa.options_values_id = '" . (int)$products_attributes[0]['value_id'] . "'";
-            }
-            $stock_query = tep_db_query($stock_query_raw);
-          } else {
-            $stock_query = tep_db_query("select products_quantity from products where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-          }
-          if (tep_db_num_rows($stock_query) > 0) {
-            $stock_values = tep_db_fetch_array($stock_query);
-// do not decrement quantities if products_attributes_filename exists
-            if ((DOWNLOAD_ENABLED != 'true') || (!$stock_values['products_attributes_filename'])) {
-              $stock_left = $stock_values['products_quantity'] - $order->products[$i]['qty'];
-            } else {
-              $stock_left = $stock_values['products_quantity'];
-            }
-            tep_db_query("update products set products_quantity = '" . (int)$stock_left . "' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-            if ( ($stock_left < 1) && (STOCK_ALLOW_CHECKOUT == 'false') ) {
-              tep_db_query("update products set products_status = '0' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-            }
-          }
-        }
-
-// Update products_ordered (for bestsellers list)
-        tep_db_query("update products set products_ordered = products_ordered + " . sprintf('%d', $order->products[$i]['qty']) . " where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-
-//------insert customer choosen option to order--------
-        $attributes_exist = '0';
-        $products_ordered_attributes = '';
-        if (isset($order->products[$i]['attributes'])) {
-          $attributes_exist = '1';
-          for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-            if (DOWNLOAD_ENABLED == 'true') {
-              $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                   from products_options popt, products_options_values poval, products_attributes pa
-                                   left join products_attributes_download pad
-                                   on pa.products_attributes_id=pad.products_attributes_id
-                                   where pa.products_id = '" . (int)$order->products[$i]['id'] . "'
-                                   and pa.options_id = '" . (int)$order->products[$i]['attributes'][$j]['option_id'] . "'
-                                   and pa.options_id = popt.products_options_id
-                                   and pa.options_values_id = '" . (int)$order->products[$i]['attributes'][$j]['value_id'] . "'
-                                   and pa.options_values_id = poval.products_options_values_id
-                                   and popt.language_id = '" . (int)$languages_id . "'
-                                   and poval.language_id = '" . (int)$languages_id . "'";
-              $attributes = tep_db_query($attributes_query);
-            } else {
-              $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . (int)$order->products[$i]['id'] . "' and pa.options_id = '" . (int)$order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . (int)$order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . (int)$languages_id . "' and poval.language_id = '" . (int)$languages_id . "'");
-            }
-            $attributes_values = tep_db_fetch_array($attributes);
-
-            $products_ordered_attributes .= "\n\t" . $attributes_values['products_options_name'] . ' ' . $attributes_values['products_options_values_name'];
-          }
-        }
-//------insert customer choosen option eof ----
-        $products_ordered .= $order->products[$i]['qty'] . ' x ' . $order->products[$i]['name'] . ' (' . $order->products[$i]['model'] . ') = ' . $currencies->display_price($order->products[$i]['final_price'], $order->products[$i]['tax'], $order->products[$i]['qty']) . $products_ordered_attributes . "\n";
-      }
-
-// lets start with the email confirmation
-      $email_order = STORE_NAME . "\n" .
-                     EMAIL_SEPARATOR . "\n" .
-                     EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_id . "\n" .
-                     EMAIL_TEXT_INVOICE_URL . ' ' . tep_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $order_id, 'SSL', false) . "\n" .
-                     EMAIL_TEXT_DATE_ORDERED . ' ' . strftime(DATE_FORMAT_LONG) . "\n\n";
-      if ($order->info['comments']) {
-        $email_order .= tep_db_output($order->info['comments']) . "\n\n";
-      }
-      $email_order .= EMAIL_TEXT_PRODUCTS . "\n" .
-                      EMAIL_SEPARATOR . "\n" .
-                      $products_ordered .
-                      EMAIL_SEPARATOR . "\n";
-
-      for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-        $email_order .= strip_tags($order_totals[$i]['title']) . ' ' . strip_tags($order_totals[$i]['text']) . "\n";
-      }
-
-      if ($order->content_type != 'virtual') {
-        $email_order .= "\n" . EMAIL_TEXT_DELIVERY_ADDRESS . "\n" .
-                        EMAIL_SEPARATOR . "\n" .
-                        tep_address_label($customer_id, $sendto, 0, '', "\n") . "\n";
-      }
-
-      $email_order .= "\n" . EMAIL_TEXT_BILLING_ADDRESS . "\n" .
-                      EMAIL_SEPARATOR . "\n" .
-                      tep_address_label($customer_id, $billto, 0, '', "\n") . "\n\n";
-
-      if (isset($GLOBALS[$payment]) && is_object($GLOBALS[$payment])) {
-        $email_order .= EMAIL_TEXT_PAYMENT_METHOD . "\n" .
-                        EMAIL_SEPARATOR . "\n";
-        $payment_class = $GLOBALS[$payment];
-        $email_order .= $payment_class->title . "\n\n";
-        if ($payment_class->email_footer) {
-          $email_order .= $payment_class->email_footer . "\n\n";
-        }
-      }
-
-      tep_mail($order->customer['firstname'] . ' ' . $order->customer['lastname'], $order->customer['email_address'], EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-
-// send emails to other people
-      if (SEND_EXTRA_ORDER_EMAILS_TO != '') {
-        tep_mail('', SEND_EXTRA_ORDER_EMAILS_TO, EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-      }
+      tep_notify('checkout', $order);
 
 // load the after_process function from the payment modules
       $this->after_process();
     }
 
     function after_process() {
-      global $cart;
-
-      $cart->reset(true);
-
-// unregister session variables used during checkout
-      tep_session_unregister('sendto');
-      tep_session_unregister('billto');
-      tep_session_unregister('shipping');
-      tep_session_unregister('payment');
-      tep_session_unregister('comments');
+      require 'includes/modules/checkout/reset.php';
 
       tep_session_unregister('cart_PayPal_Standard_ID');
 
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SUCCESS, '', 'SSL'));
+      tep_redirect(tep_href_link('checkout_success.php', '', 'SSL'));
     }
 
     function get_error() {
@@ -890,4 +634,3 @@
       }
     }
   }
-?>

--- a/includes/modules/payment/rbsworldpay_hosted.php
+++ b/includes/modules/payment/rbsworldpay_hosted.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
@@ -132,12 +132,7 @@
           $check_query = tep_db_query('select orders_id from orders_status_history where orders_id = "' . (int)$order_id . '" limit 1');
 
           if (tep_db_num_rows($check_query) < 1) {
-            tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
-            tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
-            tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-            tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
-            tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
-            tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
+            tep_delete_order($order_id);
           }
 
           $insert_order = true;
@@ -147,138 +142,10 @@
       }
 
       if ($insert_order == true) {
-        $order_totals = array();
-        if (is_array($order_total_modules->modules)) {
-          foreach($order_total_modules->modules as $value) {
-            $class = substr($value, 0, strrpos($value, '.'));
-            if ($GLOBALS[$class]->enabled) {
-              for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
-                if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
-                  $order_totals[] = array('code' => $GLOBALS[$class]->code,
-                                          'title' => $GLOBALS[$class]->output[$i]['title'],
-                                          'text' => $GLOBALS[$class]->output[$i]['text'],
-                                          'value' => $GLOBALS[$class]->output[$i]['value'],
-                                          'sort_order' => $GLOBALS[$class]->sort_order);
-                }
-              }
-            }
-          }
-        }
+        require 'includes/modules/checkout/build_order_totals.php';
+        require 'includes/modules/checkout/insert_order.php';
 
-        $sql_data_array = array('customers_id' => $customer_id,
-                                'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
-                                'customers_company' => $order->customer['company'],
-                                'customers_street_address' => $order->customer['street_address'],
-                                'customers_suburb' => $order->customer['suburb'],
-                                'customers_city' => $order->customer['city'],
-                                'customers_postcode' => $order->customer['postcode'],
-                                'customers_state' => $order->customer['state'],
-                                'customers_country' => $order->customer['country']['title'],
-                                'customers_telephone' => $order->customer['telephone'],
-                                'customers_email_address' => $order->customer['email_address'],
-                                'customers_address_format_id' => $order->customer['format_id'],
-                                'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
-                                'delivery_company' => $order->delivery['company'],
-                                'delivery_street_address' => $order->delivery['street_address'],
-                                'delivery_suburb' => $order->delivery['suburb'],
-                                'delivery_city' => $order->delivery['city'],
-                                'delivery_postcode' => $order->delivery['postcode'],
-                                'delivery_state' => $order->delivery['state'],
-                                'delivery_country' => $order->delivery['country']['title'],
-                                'delivery_address_format_id' => $order->delivery['format_id'],
-                                'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
-                                'billing_company' => $order->billing['company'],
-                                'billing_street_address' => $order->billing['street_address'],
-                                'billing_suburb' => $order->billing['suburb'],
-                                'billing_city' => $order->billing['city'],
-                                'billing_postcode' => $order->billing['postcode'],
-                                'billing_state' => $order->billing['state'],
-                                'billing_country' => $order->billing['country']['title'],
-                                'billing_address_format_id' => $order->billing['format_id'],
-                                'payment_method' => $order->info['payment_method'],
-                                'cc_type' => $order->info['cc_type'],
-                                'cc_owner' => $order->info['cc_owner'],
-                                'cc_number' => $order->info['cc_number'],
-                                'cc_expires' => $order->info['cc_expires'],
-                                'date_purchased' => 'now()',
-                                'orders_status' => $order->info['order_status'],
-                                'currency' => $order->info['currency'],
-                                'currency_value' => $order->info['currency_value']);
-
-        tep_db_perform('orders', $sql_data_array);
-
-        $insert_id = tep_db_insert_id();
-
-        for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-          $sql_data_array = array('orders_id' => $insert_id,
-                                  'title' => $order_totals[$i]['title'],
-                                  'text' => $order_totals[$i]['text'],
-                                  'value' => $order_totals[$i]['value'],
-                                  'class' => $order_totals[$i]['code'],
-                                  'sort_order' => $order_totals[$i]['sort_order']);
-
-          tep_db_perform('orders_total', $sql_data_array);
-        }
-
-        for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-          $sql_data_array = array('orders_id' => $insert_id,
-                                  'products_id' => tep_get_prid($order->products[$i]['id']),
-                                  'products_model' => $order->products[$i]['model'],
-                                  'products_name' => $order->products[$i]['name'],
-                                  'products_price' => $order->products[$i]['price'],
-                                  'final_price' => $order->products[$i]['final_price'],
-                                  'products_tax' => $order->products[$i]['tax'],
-                                  'products_quantity' => $order->products[$i]['qty']);
-
-          tep_db_perform('orders_products', $sql_data_array);
-
-          $order_products_id = tep_db_insert_id();
-
-          $attributes_exist = '0';
-          if (isset($order->products[$i]['attributes'])) {
-            $attributes_exist = '1';
-            for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-              if (DOWNLOAD_ENABLED == 'true') {
-                $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                     from products_options popt, products_options_values poval, products_attributes pa
-                                     left join products_attributes_download pad
-                                     on pa.products_attributes_id=pad.products_attributes_id
-                                     where pa.products_id = '" . $order->products[$i]['id'] . "'
-                                     and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
-                                     and pa.options_id = popt.products_options_id
-                                     and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
-                                     and pa.options_values_id = poval.products_options_values_id
-                                     and popt.language_id = '" . $languages_id . "'
-                                     and poval.language_id = '" . $languages_id . "'";
-                $attributes = tep_db_query($attributes_query);
-              } else {
-                $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
-              }
-              $attributes_values = tep_db_fetch_array($attributes);
-
-              $sql_data_array = array('orders_id' => $insert_id,
-                                      'orders_products_id' => $order_products_id,
-                                      'products_options' => $attributes_values['products_options_name'],
-                                      'products_options_values' => $attributes_values['products_options_values_name'],
-                                      'options_values_price' => $attributes_values['options_values_price'],
-                                      'price_prefix' => $attributes_values['price_prefix']);
-
-              tep_db_perform('orders_products_attributes', $sql_data_array);
-
-              if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
-                $sql_data_array = array('orders_id' => $insert_id,
-                                        'orders_products_id' => $order_products_id,
-                                        'orders_products_filename' => $attributes_values['products_attributes_filename'],
-                                        'download_maxdays' => $attributes_values['products_attributes_maxdays'],
-                                        'download_count' => $attributes_values['products_attributes_maxcount']);
-
-                tep_db_perform('orders_products_download', $sql_data_array);
-              }
-            }
-          }
-        }
-
-        $cart_RBS_Worldpay_Hosted_ID = $cartID . '-' . $insert_id;
+        $cart_RBS_Worldpay_Hosted_ID = $cartID . '-' . $order_id;
         tep_session_register('cart_RBS_Worldpay_Hosted_ID');
       }
 
@@ -298,7 +165,7 @@
                                tep_draw_hidden_field('amount', $this->format_raw($order->info['total'])) .
                                tep_draw_hidden_field('currency', $currency) .
                                tep_draw_hidden_field('desc', STORE_NAME) .
-                               tep_draw_hidden_field('name', $order->billing['firstname'] . ' ' . $order->billing['lastname']) .
+                               tep_draw_hidden_field('name', $order->billing['name']) .
                                tep_draw_hidden_field('address1', $order->billing['street_address']) .
                                tep_draw_hidden_field('town', $order->billing['city']) .
                                tep_draw_hidden_field('region', $order->billing['state']) .
@@ -389,141 +256,12 @@
 
       tep_db_perform('orders_status_history', $sql_data_array);
 
-// initialized for the email confirmation
-      $products_ordered = '';
-      $subtotal = 0;
-      $total_tax = 0;
-
-      for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-// Stock Update - Joao Correia
-        if (STOCK_LIMITED == 'true') {
-          if (DOWNLOAD_ENABLED == 'true') {
-            $stock_query_raw = "SELECT products_quantity, pad.products_attributes_filename
-                                FROM products p
-                                LEFT JOIN products_attributes pa
-                                ON p.products_id=pa.products_id
-                                LEFT JOIN products_attributes_download pad
-                                ON pa.products_attributes_id=pad.products_attributes_id
-                                WHERE p.products_id = '" . tep_get_prid($order->products[$i]['id']) . "'";
-// Will work with only one option for downloadable products
-// otherwise, we have to build the query dynamically with a loop
-            $products_attributes = $order->products[$i]['attributes'];
-            if (is_array($products_attributes)) {
-              $stock_query_raw .= " AND pa.options_id = '" . $products_attributes[0]['option_id'] . "' AND pa.options_values_id = '" . $products_attributes[0]['value_id'] . "'";
-            }
-            $stock_query = tep_db_query($stock_query_raw);
-          } else {
-            $stock_query = tep_db_query("select products_quantity from products where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-          }
-          if (tep_db_num_rows($stock_query) > 0) {
-            $stock_values = tep_db_fetch_array($stock_query);
-// do not decrement quantities if products_attributes_filename exists
-            if ((DOWNLOAD_ENABLED != 'true') || (!$stock_values['products_attributes_filename'])) {
-              $stock_left = $stock_values['products_quantity'] - $order->products[$i]['qty'];
-            } else {
-              $stock_left = $stock_values['products_quantity'];
-            }
-            tep_db_query("update products set products_quantity = '" . $stock_left . "' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-            if ( ($stock_left < 1) && (STOCK_ALLOW_CHECKOUT == 'false') ) {
-              tep_db_query("update products set products_status = '0' where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-            }
-          }
-        }
-
-// Update products_ordered (for bestsellers list)
-        tep_db_query("update products set products_ordered = products_ordered + " . sprintf('%d', $order->products[$i]['qty']) . " where products_id = '" . tep_get_prid($order->products[$i]['id']) . "'");
-
-//------insert customer choosen option to order--------
-        $attributes_exist = '0';
-        $products_ordered_attributes = '';
-        if (isset($order->products[$i]['attributes'])) {
-          $attributes_exist = '1';
-          for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-            if (DOWNLOAD_ENABLED == 'true') {
-              $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                   from products_options popt, products_options_values poval, products_attributes pa
-                                   left join products_attributes_download pad
-                                   on pa.products_attributes_id=pad.products_attributes_id
-                                   where pa.products_id = '" . $order->products[$i]['id'] . "'
-                                   and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
-                                   and pa.options_id = popt.products_options_id
-                                   and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
-                                   and pa.options_values_id = poval.products_options_values_id
-                                   and popt.language_id = '" . $languages_id . "'
-                                   and poval.language_id = '" . $languages_id . "'";
-              $attributes = tep_db_query($attributes_query);
-            } else {
-              $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from products_options popt, products_options_values poval, products_attributes pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
-            }
-            $attributes_values = tep_db_fetch_array($attributes);
-
-            $products_ordered_attributes .= "\n\t" . $attributes_values['products_options_name'] . ' ' . $attributes_values['products_options_values_name'];
-          }
-        }
-//------insert customer choosen option eof ----
-        $total_weight += ($order->products[$i]['qty'] * $order->products[$i]['weight']);
-        $total_tax += tep_calculate_tax($total_products_price, $products_tax) * $order->products[$i]['qty'];
-        $total_cost += $total_products_price;
-
-        $products_ordered .= $order->products[$i]['qty'] . ' x ' . $order->products[$i]['name'] . ' (' . $order->products[$i]['model'] . ') = ' . $currencies->display_price($order->products[$i]['final_price'], $order->products[$i]['tax'], $order->products[$i]['qty']) . $products_ordered_attributes . "\n";
-      }
-
-// lets start with the email confirmation
-      $email_order = STORE_NAME . "\n" .
-                     EMAIL_SEPARATOR . "\n" .
-                     EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_id . "\n" .
-                     EMAIL_TEXT_INVOICE_URL . ' ' . tep_href_link('account_history_info.php', 'order_id=' . $order_id, 'SSL', false) . "\n" .
-                     EMAIL_TEXT_DATE_ORDERED . ' ' . strftime(DATE_FORMAT_LONG) . "\n\n";
-      if ($order->info['comments']) {
-        $email_order .= tep_db_output($order->info['comments']) . "\n\n";
-      }
-      $email_order .= EMAIL_TEXT_PRODUCTS . "\n" .
-                      EMAIL_SEPARATOR . "\n" .
-                      $products_ordered .
-                      EMAIL_SEPARATOR . "\n";
-
-      for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-        $email_order .= strip_tags($order_totals[$i]['title']) . ' ' . strip_tags($order_totals[$i]['text']) . "\n";
-      }
-
-      if ($order->content_type != 'virtual') {
-        $email_order .= "\n" . EMAIL_TEXT_DELIVERY_ADDRESS . "\n" .
-                        EMAIL_SEPARATOR . "\n" .
-                        tep_address_label($customer_id, $sendto, 0, '', "\n") . "\n";
-      }
-
-      $email_order .= "\n" . EMAIL_TEXT_BILLING_ADDRESS . "\n" .
-                      EMAIL_SEPARATOR . "\n" .
-                      tep_address_label($customer_id, $billto, 0, '', "\n") . "\n\n";
-
-      if (is_object($$payment)) {
-        $email_order .= EMAIL_TEXT_PAYMENT_METHOD . "\n" .
-                        EMAIL_SEPARATOR . "\n";
-        $payment_class = $$payment;
-        $email_order .= $payment_class->title . "\n\n";
-        if ($payment_class->email_footer) {
-          $email_order .= $payment_class->email_footer . "\n\n";
-        }
-      }
-
-      tep_mail($order->customer['firstname'] . ' ' . $order->customer['lastname'], $order->customer['email_address'], EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-
-// send emails to other people
-      if (SEND_EXTRA_ORDER_EMAILS_TO != '') {
-        tep_mail('', SEND_EXTRA_ORDER_EMAILS_TO, EMAIL_TEXT_SUBJECT, $email_order, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
-      }
+      tep_notify('checkout', $order);
 
 // load the after_process function from the payment modules
       $this->after_process();
 
-      $cart->reset(true);
-
-// unregister session variables used during checkout
-      tep_session_unregister('sendto');
-      tep_session_unregister('billto');
-      tep_session_unregister('shipping');
-      tep_session_unregister('payment');
-      tep_session_unregister('comments');
+      require 'includes/modules/checkout/reset.php';
 
       tep_session_unregister('cart_RBS_Worldpay_Hosted_ID');
 

--- a/includes/modules/payment/sage_pay_server.php
+++ b/includes/modules/payment/sage_pay_server.php
@@ -5,13 +5,26 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
 
   class sage_pay_server {
-    var $code, $title, $description, $enabled;
+
+    const REQUIRES = [
+      'firstname',
+      'lastname',
+      'street_address',
+      'city',
+      'postcode',
+      'country',
+      'telephone',
+      'email_address',
+    ];
+
+    public $code = 'sage_pay_server';
+    public $title, $description, $enabled;
 
     function __construct() {
       global $PHP_SELF, $order;
@@ -19,7 +32,6 @@
       $this->signature = 'sage_pay|sage_pay_server|2.0|2.3';
       $this->api_version = '3.00';
 
-      $this->code = 'sage_pay_server';
       $this->title = MODULE_PAYMENT_SAGE_PAY_SERVER_TEXT_TITLE;
       $this->public_title = MODULE_PAYMENT_SAGE_PAY_SERVER_TEXT_PUBLIC_TITLE;
       $this->description = MODULE_PAYMENT_SAGE_PAY_SERVER_TEXT_DESCRIPTION;
@@ -280,14 +292,7 @@
       if ( MODULE_PAYMENT_SAGE_PAY_SERVER_PROFILE_PAGE == 'Low' ) {
         global $cart;
 
-        $cart->reset(true);
-
-// unregister session variables used during checkout
-        tep_session_unregister('sendto');
-        tep_session_unregister('billto');
-        tep_session_unregister('shipping');
-        tep_session_unregister('payment');
-        tep_session_unregister('comments');
+        require 'includes/modules/checkout/reset.php';
 
         tep_session_unregister('sage_pay_server_nexturl');
 
@@ -702,4 +707,3 @@ EOD;
       }
     }
   }
-?>


### PR DESCRIPTION
Moves 

1.  Build order totals.
2.  Order insertion.
3.  Order notification.
4.  Checkout variables reset.
5.  Order deletion.

Into their own modules or functions.  In general, this reduces the amount of places where a change needs to be made.  

Add a 'name' field to the order groups for customer, shipping, and billing, generally those that require separate first and last names.  

Adds requirement management to payment modules.  

Renames insert_id to order_id for clarity and because it was easier than renaming order_id to insert_id for consistency's sake.  

Update copyright year for modified files.  

Replace FILENAME_ variables with the filenames.  

Update var to public.  

Standardize on ANSI quoting for compatibility's sake.  