### PR TITLE
Cloudflare external libraries

### DIFF
--- a/includes/hooks/shop/siteWide/bootStrap.php
+++ b/includes/hooks/shop/siteWide/bootStrap.php
@@ -22,7 +22,7 @@ class hook_shop_siteWide_bootStrap {
   
   function listen_injectSiteStart() {
     $this->sitestart .= '<!-- bs hooked -->' . PHP_EOL;
-    $this->sitestart .= '<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">' . PHP_EOL;
+    $this->sitestart .= '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">' . PHP_EOL;
 
     return $this->sitestart;
   }
@@ -30,7 +30,7 @@ class hook_shop_siteWide_bootStrap {
   function listen_injectSiteEnd() {
     $this->siteend .= '<!-- bs hooked -->' . PHP_EOL;
     $this->siteend .= '<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>' . PHP_EOL;
-    $this->siteend .= '<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>' . PHP_EOL;
+    $this->siteend .= '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>' . PHP_EOL;
 
     return $this->siteend;
   }

--- a/includes/hooks/shop/siteWide/fontAwesome.php
+++ b/includes/hooks/shop/siteWide/fontAwesome.php
@@ -21,7 +21,7 @@ class hook_shop_siteWide_fontAwesome {
 
   function listen_injectSiteStart() {
     $this->sitestart .= '<!-- fa hooked -->' . PHP_EOL;
-    $this->sitestart .= '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.11.2/css/all.css" crossorigin="anonymous">' . PHP_EOL;
+    $this->sitestart .= '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" crossorigin="anonymous">' . PHP_EOL;
 
     return $this->sitestart;
   }

--- a/includes/hooks/shop/siteWide/jQuery.php
+++ b/includes/hooks/shop/siteWide/jQuery.php
@@ -21,7 +21,7 @@ class hook_shop_siteWide_jQuery {
 
   function listen_injectAfterFooter() {
     $this->afterfooter .= '<!-- jquery hooked -->' . PHP_EOL;
-    $this->afterfooter .= '<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>' . PHP_EOL;
+    $this->afterfooter .= '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>' . PHP_EOL;
 
     return $this->afterfooter;
   }


### PR DESCRIPTION
The gtmetrix.com site complains that the demo shop uses more than four domains.  This change moves the jQuery, BootStrap, and FontAwesome scripts to the CDNJS Cloudflare CDN.  That drops the number of domains on the demo site to exactly four:  template.me.uk, cdnjs.cloudflare.com, www.googletagmanager.com, and www.google-analytics.com.  The Google site links are not distributed with the core install and probably need to be downloaded directly regardless.  So this leaves only the store itself and the CDNJS domain for the core install.  