### PR TITLE
Admin autoloader 

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */

--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -46,6 +46,12 @@
   define('LOCAL_EXE_ZIP', 'zip');
   define('LOCAL_EXE_UNZIP', 'unzip');
 
+  // autoload classes in the classes or modules directories
+  require DIR_FS_CATALOG . 'includes/functions/autoloader.php';
+  require 'includes/functions/autoloader.php';
+  spl_autoload_register('tep_autoload_admin');
+  spl_autoload_register('tep_autoload_catalog');
+
 // include the list of project database tables
   require('includes/database_tables.php');
 

--- a/admin/includes/functions/autoloader.php
+++ b/admin/includes/functions/autoloader.php
@@ -1,0 +1,54 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2019 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  function tep_build_admin_autoload_index($modules_directory_length) {
+    $class_files = [];
+    
+    tep_find_all_files_under(DIR_FS_ADMIN . 'includes/modules', $class_files);
+    tep_find_all_files_under(DIR_FS_ADMIN . 'includes/classes', $class_files);
+    
+    // some classes do not follow either naming standard relating the class name and file name
+    $exception_mappings = [
+      'Password_hash' => 'passwordhash',
+    ];
+
+    foreach ($exception_mappings as $class_name => $filename) {
+      $class_files[$class_name] = $class_files[$filename];
+      unset($class_files[$filename]);
+    }
+
+    return $class_files;
+  }
+
+  function tep_autoload_admin($class) {
+    static $class_files;
+    static $modules_directory_length;
+
+    if (!isset($class_files)) {
+      $modules_directory_length = strlen(DIR_FS_ADMIN . 'includes/modules');
+      $class_files = tep_build_admin_autoload_index($modules_directory_length);
+    }
+
+    // convert camelCase class names to snake_case filenames
+    $class = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $class));
+
+    if (isset($class_files[$class])) {
+      if (isset($GLOBALS['language']) && DIR_FS_ADMIN . 'includes/modules' === substr($class_files[$class], 0, $modules_directory_length)) {
+        $language_file = DIR_FS_ADMIN . 'includes/languages/'. $GLOBALS['language'] . '/modules' . substr($class_files[$class], $modules_directory_length);
+        if (file_exists($language_file)) {
+          include $language_file;
+        }
+      }
+
+      require $class_files[$class];
+    }
+  }


### PR DESCRIPTION
Updates the catalog autoloader functions to explicitly sort and creates a separate function for building the index of class files.

Adds an admin autoloader function.

Modifies the admin/includes/application_top.php to register the admin and catalog autoloaders in that order. So if a class exists in admin, it will use that one. If not, it will look in catalog.
