### PR TITLE
Contact us language

### DIFF
--- a/contact_us.php
+++ b/contact_us.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2018 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */

--- a/contact_us.php
+++ b/contact_us.php
@@ -39,7 +39,7 @@
     }
 
     if ($error == false) {
-      tep_mail(STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS, EMAIL_SUBJECT, $enquiry, $name, $email_address);
+      tep_mail(STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS, sprintf(EMAIL_SUBJECT, STORE_NAME), $enquiry, $name, $email_address);
 
       $actionRecorder->record();
 
@@ -99,7 +99,7 @@
     <label for="inputFromEmail" class="col-sm-3 col-form-label text-right"><?php echo ENTRY_EMAIL; ?></label>
     <div class="col-sm-9">
       <?php
-      echo tep_draw_input_field('email', NULL, 'required aria-required="true" id="inputFromEmail" placeholder="' . ENTRY_EMAIL_ADDRESS_TEXT . '"', 'email');
+      echo tep_draw_input_field('email', NULL, 'required aria-required="true" id="inputFromEmail" placeholder="' . ENTRY_EMAIL_TEXT . '"', 'email');
       echo FORM_REQUIRED_INPUT;
       ?>
     </div>

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -104,7 +104,6 @@ define('ENTRY_POST_CODE_TEXT', '');
 define('ENTRY_CITY', 'City');
 define('ENTRY_CITY_ERROR', 'Your City must contain a minimum of ' . ENTRY_CITY_MIN_LENGTH . ' characters.');
 define('ENTRY_CITY_TEXT', '');
-define('ENTRY_NAME_TEXT', '');
 define('ENTRY_STATE', 'State/Province');
 define('ENTRY_STATE_ERROR', 'Your State must contain a minimum of ' . ENTRY_STATE_MIN_LENGTH . ' characters.');
 define('ENTRY_STATE_ERROR_SELECT', 'Please select a state from the States pull down menu.');

--- a/includes/languages/english/contact_us.php
+++ b/includes/languages/english/contact_us.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2002 osCommerce
+  Copyright (c) 2019 osCommerce
 
   Released under the GNU General Public License
 */
@@ -13,12 +13,13 @@
 define('HEADING_TITLE', 'Contact Us');
 define('NAVBAR_TITLE', 'Contact Us');
 define('TEXT_SUCCESS', 'Your enquiry has been successfully sent to the Store Owner.');
-define('EMAIL_SUBJECT', 'Enquiry from ' . STORE_NAME);
+define('EMAIL_SUBJECT', 'Enquiry from %s');
 
 define('ENTRY_NAME', 'Full Name');
+define('ENTRY_NAME_TEXT', '');
 define('ENTRY_EMAIL', 'E-Mail Address');
+define('ENTRY_EMAIL_TEXT', '');
 define('ENTRY_ENQUIRY', 'Enquiry');
 define('ENTRY_ENQUIRY_TEXT', '');
 
 define('ERROR_ACTION_RECORDER', 'Error: An enquiry has already been sent. Please try again in %s minutes.');
-?>


### PR DESCRIPTION
Move Contact Us specific language defines out of english.php and into english/contact_us.php

Adjust contact_us.php to use a Contact Us specific name for the email text.  

Make contact_us.php do the work of inserting the store name into the email subject string.  As that needs to be done at run time under the current system while the language values could be set at compile time.  