### PR TITLE
Autoloader typo

### DIFF
--- a/admin/includes/functions/autoloader.php
+++ b/admin/includes/functions/autoloader.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2019 osCommerce
+  Copyright (c) 2020 osCommerce
 
   Released under the GNU General Public License
 */
@@ -18,7 +18,7 @@
     
     // some classes do not follow either naming standard relating the class name and file name
     $exception_mappings = [
-      'Password_hash' => 'passwordhash',
+      'password_hash' => 'passwordhash',
     ];
 
     foreach ($exception_mappings as $class_name => $filename) {

--- a/includes/functions/autoloader.php
+++ b/includes/functions/autoloader.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2019 osCommerce
+  Copyright (c) 2020 osCommerce
 
   Released under the GNU General Public License
 */
@@ -44,7 +44,7 @@
       'alert_block' => 'alertbox',
       'os_c__actions' => 'actions',
       'm_c_a_p_i' => 'MCAPI.class',
-      'Password_hash' => 'passwordhash',
+      'password_hash' => 'passwordhash',
     ];
 
     foreach ($exception_mappings as $class_name => $filename) {


### PR DESCRIPTION
The snake_cased version will be all lower case.  Fixed in catalog and admin.  

Tested by adding a product to the shopping cart, which wasn't working but does after this change.  