### PR TITLE
Deprecate tep_class_exists()

### DIFF
--- a/admin/action_recorder.php
+++ b/admin/action_recorder.php
@@ -36,7 +36,7 @@
     include(DIR_FS_CATALOG_MODULES . 'action_recorder/' . $file);
 
     $class = substr($file, 0, strrpos($file, '.'));
-    if (tep_class_exists($class)) {
+    if (class_exists($class)) {
       ${$class} = new $class;
     }
   }

--- a/admin/includes/modules/dashboard/d_security_checks.php
+++ b/admin/includes/modules/dashboard/d_security_checks.php
@@ -55,7 +55,7 @@
         include(DIR_FS_ADMIN . 'includes/modules/security_check/' . $secmodule);
 
         $secclass = 'securityCheck_' . substr($secmodule, 0, strrpos($secmodule, '.'));
-        if (tep_class_exists($secclass)) {
+        if (class_exists($secclass)) {
           $secCheck = new $secclass;
 
           if ( !$secCheck->pass() ) {

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -148,7 +148,7 @@
               include($module_directory . $file);
 
               $class = substr($file, 0, strrpos($file, '.'));
-              if (tep_class_exists($class)) {
+              if (class_exists($class)) {
                 $module = new $class;
                 if ($module->check() > 0) {
                   if (($module->sort_order > 0) && !isset($installed_modules[$module->sort_order])) {

--- a/admin/modules_content.php
+++ b/admin/modules_content.php
@@ -32,7 +32,7 @@
               if (substr($file, strrpos($file, '.')) == $file_extension) {
                 $class = substr($file, 0, strrpos($file, '.'));
 
-                if (!tep_class_exists($class)) {
+                if (!class_exists($class)) {
                   if ( file_exists(DIR_FS_CATALOG_LANGUAGES . $language . '/modules/content/' . $group . '/' . $file) ) {
                     include(DIR_FS_CATALOG_LANGUAGES . $language . '/modules/content/' . $group . '/' . $file);
                   }
@@ -40,7 +40,7 @@
                   include(DIR_FS_CATALOG_MODULES . 'content/' . $group . '/' . $file);
                 }
 
-                if (tep_class_exists($class)) {
+                if (class_exists($class)) {
                   $module = new $class();
 
                   if (in_array($group . '/' . $class, $modules_installed)) {


### PR DESCRIPTION
Deprecate the tep_class_exists function, which is now just a wrapper for class_exists.  Will allow the function to be deleted in some future version.  