### PR TITLE
Unify pipeline, page, and siteWide hooks

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -224,6 +224,4 @@
   require('includes/classes/cfg_modules.php');
   $cfgModules = new cfg_modules();
 
-  $OSCOM_Hooks->register('siteWide');
-
-  $OSCOM_Hooks->register(basename($PHP_SELF, '.php'));
+  $OSCOM_Hooks->register_page();

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -386,8 +386,6 @@
     }
   }
 
-  $OSCOM_Hooks->register('siteWide');
+  $OSCOM_Hooks->register_page();
   $OSCOM_Hooks->call('siteWide', 'injectAppTop');
-
-  $OSCOM_Hooks->register(basename($PHP_SELF, '.php'));
 


### PR DESCRIPTION
Creates a concept of pipeline hooks.  A pipeline being a group of pages with the same hook call.  

Modifies registration so that hooks can be registered to aliases.  

Registers pipeline and siteWide hooks to the current page.  So a siteWide hook will run for any invocation.  A pipeline hook will run for any invocation on a page that registers that pipeline (after the pipeline is registered).  A page hook will only trigger on the page that registers it.  